### PR TITLE
Include the Laravel env() polyfill.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     ],
     "require": {
         "php": ">=7.1.3",
-        "illuminate/support": "~5.8.0|~5.9.0"
+        "illuminate/support": "~5.8.0|~5.9.0",
+        "phpexperts/laravel-env-polyfill": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0"


### PR DESCRIPTION
I created the Laravel 5.7 env() polyfill project back with the release of Laravel 5.8.

Using this env() helper will ensure that it will always read from `getenv()`, even if the Laravel devs decide to do away with that functionality (again) in the future.

The env() function is conspicuously missing from this project, so I figured, why not just add a dependency for it?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/laravel/helpers/7)
<!-- Reviewable:end -->
