### PR TITLE
Add compatibility for ~5.5.0|~5.6.0|~5.7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": ">=7.1.3",
-        "illuminate/support": "~5.8.0|^6.0|^7.0"
+        "illuminate/support": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0|^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0"


### PR DESCRIPTION
Can you merge this? Need it because work on a package that work with Laravel from 5.5.0 to 6.0 and need helpers. 