### PR TITLE
use func_get_args to pass array_prepend call through to Arr::prepend …

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -199,7 +199,7 @@ if (! function_exists('array_prepend')) {
      */
     function array_prepend($array, $value, $key = null)
     {
-        return Arr::prepend($array, $value, $key);
+        return Arr::prepend(...func_get_args());
     }
 }
 


### PR DESCRIPTION
Currently calling `array_prepend()` with a missing third (`$key`) argument calls `Arr::prepend()` with three arguments, the third being the default `null` value from the `array_prepend()` definition. However, `Arr::prepend()` uses `func_num_args()` to check if the third argument is set. This leads to the element being prepended with an empty key (and any subsequent calls of `array_prepend()` (without supplying a third argument) overwriting the inserted element).

Using `...func_get_args()` leads to the third argument of the `Arr::prepend()` call not being set if no third argument is supplied to `array_prepend(),` thus enabling correct handling of numeric indices.