### PR TITLE
Fix implicitly nullable parameters for PHP 8.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.2, 7.3, 7.4, '8.0', 8.1, 8.2, 8.3]
+        php: [7.2, 7.3, 7.4, '8.0', 8.1, 8.2, 8.3, 8.4]
 
     name: PHP ${{ matrix.php }}
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -81,7 +81,7 @@ if (! function_exists('array_first')) {
      * @param  mixed  $default
      * @return mixed
      */
-    function array_first($array, callable $callback = null, $default = null)
+    function array_first($array, ?callable $callback = null, $default = null)
     {
         return Arr::first($array, $callback, $default);
     }
@@ -153,7 +153,7 @@ if (! function_exists('array_last')) {
      * @param  mixed  $default
      * @return mixed
      */
-    function array_last($array, callable $callback = null, $default = null)
+    function array_last($array, ?callable $callback = null, $default = null)
     {
         return Arr::last($array, $callback, $default);
     }


### PR DESCRIPTION
When testing PHP 8.4 in my local environment and running `composer update` to get the newer packages I noticed a couple of deprecation warnings.

- `Deprecated: array_first(): Implicitly marking parameter $callback as nullable is deprecated, the explicit nullable type must be used instead in /app/vendor/laravel/helpers/src/helpers.php on line 84`
- `Deprecated: array_last(): Implicitly marking parameter $callback as nullable is deprecated, the explicit nullable type must be used instead in /app/vendor/laravel/helpers/src/helpers.php on line 156`

This updates the signature of those two methods.

[RFC for deprecation.](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types)