### PR TITLE
Prevent infinite loop on array_first, array_last, str_contains

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -83,7 +83,21 @@ if (! function_exists('array_first')) {
      */
     function array_first($array, ?callable $callback = null, $default = null)
     {
-        return Arr::first($array, $callback, $default);
+        if (is_null($callback)) {
+            if (empty($array)) {
+                return value($default);
+            }
+
+            foreach ($array as $item) {
+                return $item;
+            }
+
+            return value($default);
+        }
+
+        $key = array_find_key($array, $callback);
+
+        return $key !== null ? $array[$key] : value($default);
     }
 }
 
@@ -155,7 +169,11 @@ if (! function_exists('array_last')) {
      */
     function array_last($array, ?callable $callback = null, $default = null)
     {
-        return Arr::last($array, $callback, $default);
+        if (is_null($callback)) {
+            return empty($array) ? value($default) : end($array);
+        }
+
+        return Arr::first(array_reverse($array, true), $callback, $default);
     }
 }
 
@@ -409,7 +427,21 @@ if (! function_exists('str_contains')) {
      */
     function str_contains($haystack, $needles)
     {
-        return Str::contains($haystack, $needles);
+        if (is_null($haystack)) {
+            return false;
+        }
+
+        if (! is_iterable($needles)) {
+            $needles = (array) $needles;
+        }
+
+        foreach ($needles as $needle) {
+            if ($needle !== '' && strpos($haystack, $needle) !== false) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }
 


### PR DESCRIPTION
Recently some `Illuminate\Collection\Arr` helpers were changed to use the new `array_first` and `array_last` functions introduced in PHP 8.5.

These changes were introduced on PR https://github.com/laravel/framework/pull/56706

Although PHP 8.5 is yet to be released, these changes were possible by requiring the `symfony/polyfill-php85` package.

The issue is, if a package requires the `laravel/helpers` package, it also defines `array_first` and `array_last` functions.

Then if `laravel/helpers` gets loaded before `symfony/polyfill-php85` the functions defined in `laravel/helpers` will take precedence.

And currently the definitions of these functions will create an infinite loop, as they both are just an alias to `Arr::first()` and `Arr::last()`, and those call `array_first` and `array_last` within their implementation.

https://github.com/laravel/helpers/blob/bc2846466cdc5025d0c11cd696429509f869f7b6/src/helpers.php#L84-L87

https://github.com/laravel/helpers/blob/bc2846466cdc5025d0c11cd696429509f869f7b6/src/helpers.php#L156-L159

During the assessment for this PR, I noted that the `str_contains()` helper can also result in an infinite loop.

https://github.com/laravel/helpers/blob/bc2846466cdc5025d0c11cd696429509f869f7b6/src/helpers.php#L410-L413

Although the native `str_contains` function was first introduced in PHP 8.0, the `laravel/helpers` package supports PHP versions as old as PHP 7.2, so I thought of also handling this helper.

**This PR**

- Copies the previous implementation of `Arr::first()`, `Arr::last()` and `Str::contains()` directly into the `array_first`, `array_last` and `str_contains` helpers to avoid an infinite loop.
- Deprecation notes were added to these helpers' docblocks.
- No tests were added as no new tests are being accepted.

For a future PR, it would be good to add deprecation notes for the helpers that are named the same as PHP native functions.
