### PR TITLE
avoid array_find_key

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -98,9 +98,13 @@ if (! function_exists('array_first')) {
             return value($default);
         }
 
-        $key = array_find_key($array, $callback);
+        foreach ($array as $key => $value) {
+            if ($callback($value, $key)) {
+                return $value;
+            }
+        }
 
-        return $key !== null ? $array[$key] : value($default);
+        return value($default);
     }
 }
 


### PR DESCRIPTION
PR #37 reverted some helpers to avoid infinite loops on helpers named as newly introduced PHP functions.

The approach was to copy over the implementations from `Illuminate\Support\Arr` and `Illuminate\Support\Str` before the clashing functions were introduced.

For the `array_first()` helper, the previous `Arr::first` implementation relied on the `array_find_key()` function. But this function was only introduced in PHP 8.4

Reference: https://www.php.net/manual/en/function.array-find-key.php

As this package supports PHP versions as old as PHP 7.2, that PR introduced a bug for projects using PHP versions less than PHP 8.4 that do not have any polyfills to provide the `array_find_key()` function.

**This PR**

- Reverts the code using the `array_find_key()` function to the previous implementation on `Illuminate\Support\Arr@first()`

I verified the other changes, and they don't use any other functions like this. The most recent function used other than `array_find_key()` is the `is_iterable()` function, which was introduced on PHP 7.1.

The `array_first()` implementation on this PR matches the one in this version:

https://github.com/laravel/framework/blob/7eeeed0831a799a78f8144d90af567733c171405/src/Illuminate/Collections/Arr.php#L252-L273

The implementation on PR #37 was based on this version:

https://github.com/laravel/framework/blob/7d7fe2312bc17734670e99a4e78d22a1f7bb7621/src/Illuminate/Collections/Arr.php#L252-L269

One can use the blame option in GitHub to verify the changes between these two versions were only due to adopting the `array_find_key()` function introduced in PHP 8.3.